### PR TITLE
bug: colons in script names truncate output

### DIFF
--- a/src/scripts.rs
+++ b/src/scripts.rs
@@ -14,6 +14,7 @@ pub async fn provide_scripts_candidate(target_pkg: Option<&str>) -> anyhow::Resu
 
     let scripts = scripts
         .map(|scripts| scripts.keys().join("\n"))
-        .unwrap_or_default();
+        .unwrap_or_default()
+        .replace(":", "\\:");
     Ok(scripts)
 }


### PR DESCRIPTION
A colon in the name of a script truncates the output.
this resolves that.

**Before:**
(see there are two `test` scripts listed, when the second one should say `test:broken`)
![broken completion output with colons](https://github.com/g-plane/pnpm-shell-completion/assets/9210782/8c4f39d1-944f-4bb2-94bb-f168ba0e1830)

**After:**
![fixed completion output with colons](https://github.com/g-plane/pnpm-shell-completion/assets/9210782/1918af72-81cb-4484-9a3f-5b9f6e64675c)


fixes: g-plane/pnpm-shell-completion#8