### PR TITLE
Update zplug.zsh

### DIFF
--- a/zplug.zsh
+++ b/zplug.zsh
@@ -1,4 +1,4 @@
-#!/usr/bin/zsh
+#!/usr/bin/env zsh
 set -e
 
 local version=$(grep '^version =' Cargo.toml | cut -d'"' -f2)


### PR DESCRIPTION
resolve macos m1 :
(eval):1: ./zplug.zsh: bad interpreter: /usr/bin/zsh: no such file or directory