### PR TITLE
build: use REAL m1 runner for aarch64 darwin builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
           - host: macos-latest
             target: x86_64-apple-darwin
             build: cargo build --release
-          - host: macos-latest
+          - host: macos-14
             target: aarch64-apple-darwin
             build: |
               sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*;


### PR DESCRIPTION
This commit fixed the wrong configuration in GitHub Workflow.

According to [this document](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#:~:text=The%20macos%2Dlatest%20workflow%20label%20currently%20uses%20the%20macOS%2012%20runner%20image.), `macos-latest` is an alias of `macos-12` at present, which leads to a wrong build architecture in the assets.

This is the executable from the latest release (v0.5.3):
```
Info:
    File name: pnpm-shell-completion_aarch64-apple-darwin (053)/pnpm-shell-completion
    Size: 1980624
    Operation system: macOS(12.0.0)
    Architecture: X86_64
    Mode: 64-bit
    Type: EXECUTE
    Endianness: LE
```

And here is the new one:
```
Info:
    File name: pnpm-shell-completion_aarch64-apple-darwin/pnpm-shell-completion
    Size: 1810024
    Operation system: macOS(14.0.0)
    Architecture: ARM64
    Mode: 64-bit
    Type: EXECUTE
    Endianness: LE
```