### PR TITLE
fix(zplug): generic shebang

### DIFF
--- a/zplug.zsh
+++ b/zplug.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 set -e
 
 local version=$(grep '^version =' Cargo.toml | cut -d'"' -f2)


### PR DESCRIPTION
This PR changes the shebang of the `zplug.zsh` file for the script to be portable across distributions, specifically making it work with NixOS.