### PR TITLE
overwrite shell completion cmd if it already exists

### DIFF
--- a/zplug.zsh
+++ b/zplug.zsh
@@ -21,5 +21,5 @@ else
     curl -fsSL $url -o zipball.zip
 fi
 
-unzip zipball.zip pnpm-shell-completion
+unzip -o zipball.zip pnpm-shell-completion
 rm zipball.zip


### PR DESCRIPTION
If you rerun `zplug.zsh` (on an update or otherwise), it will fail due to `unzip` not overwriting the previously installed cmd.

Manually run, it will prompt if you want to overwrite but when used from a zsh framework (such as zimfw), it will not have interactivity. 

```
x pnpm-shell-completion: Error during on-pull
  Archive:  zipball.zip
  replace pnpm-shell-completion? [y]es, [n]o, [A]ll, [N]one, [r]ename:  NULL
  (EOF or read error, treating as "[N]one" ...)
```