### PR TITLE
feat: several improve to fish version

### DIFF
--- a/pnpm.fish
+++ b/pnpm.fish
@@ -1,5 +1,3 @@
-set -g filter_flag
-
 set -g __fish_pnpm_cmdline
 set -g __fish_pnpm_remove_cmdline
 
@@ -8,12 +6,13 @@ set -l up_commands update upgrade up
 set -l install_commands install i
 
 complete -c pnpm -f
-complete -c pnpm -n "not __fish_seen_subcommand_from $deps_commands" -a "(__get_scripts)"
+complete -c pnpm -a "(__get_scripts)"
 complete -c pnpm -f -l filter -s F -r -a "$(FEATURE=filter pnpm-shell-completion)" -d 'Select specified packages'
-# add relative args
-complete -c pnpm -n "not __fish_use_subcommand" -f -a "add remove install update publish"
-complete -c pnpm -n __could_add_global -l global -s g
+complete -c pnpm -n "__fish_use_subcommand; or __has_filter" -f -a 'add remove install update publish'
+complete -c pnpm -n "not __fish_use_subcommand" -F
 
+# add relative options
+complete -c pnpm -n __could_add_global -l global -s g -d 'Install a global package'
 complete -c pnpm -n "__fish_seen_subcommand_from add" -l save-dev -s D -d 'Save package to your `devDependencies`'
 complete -c pnpm -n "__fish_seen_subcommand_from add" -l save-peer -d 'Save package to your `peerDependencies` and `devDependencies`'
 
@@ -78,18 +77,17 @@ function __has_filter
   set -l tokens (commandline -opc)
   set -e tokens[1] # assume the first token is `pnpm`
   argparse 'F/filter=' -- $tokens 2>/dev/null
-  if count $_flag_filter == 0
+  if not count $_flag_filter
     return 1
   end
   return 0
 end
 
-# predicate function, 1 means false, 0 means true
 function __could_add_global
-  if __has_filter == 0
+  if __has_filter
     return 1
   end
-  if __fish_seen_subcommand_from add == 0
+  if __fish_seen_subcommand_from add
     return 0
   end
   return 1


### PR DESCRIPTION
Bug fix:
1. fish don't support return value check in `if` block. In original version ([line 89](https://github.com/OrkWard/pnpm-shell-completion/blob/57741305cc4232c64240d5169c2b9d08ddaf853e/pnpm.fish#L89) and [line 92](https://github.com/OrkWard/pnpm-shell-completion/blob/57741305cc4232c64240d5169c2b9d08ddaf853e/pnpm.fish#L92)), the `== 0` was treated as function params, which completely ignored. Remove for clarify.
2. [line 81](https://github.com/OrkWard/pnpm-shell-completion/blob/57741305cc4232c64240d5169c2b9d08ddaf853e/pnpm.fish#L81) the `count` builtin check how many params are passed, the `== 0` causes it to always return true. (which makes both user-define function useless)
3. [line 14](https://github.com/OrkWard/pnpm-shell-completion/blob/57741305cc4232c64240d5169c2b9d08ddaf853e/pnpm.fish#L14) `-n "not __fish_use_subcommand"`  prevent these commands(`add` / `remove` / ... list here) to be completed when there are no sub-command, which do the contrary to what it supposed.

Feat:
1. Remove condition limit for scripts completion. The original version prevents scripts only when user has input `remove` / `why` / `update`, which, in my view, is not so useful.
2. Allow file completion when seen sub-command, allow use case like this:
```fish
$ pnpm run test ./<TAB>
./foo.spec.ts ./bar.spec.ts
```

Chore:
Remove useless value define at the first line.

Btw, folks care about your telegram account status @g-plane 